### PR TITLE
Issue 18 - allow loading assets via XCC

### DIFF
--- a/src/main/java/com/marklogic/appdeployer/command/modules/CommaDelimitedPermissionsParser.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/CommaDelimitedPermissionsParser.java
@@ -1,0 +1,35 @@
+package com.marklogic.appdeployer.command.modules;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.marklogic.xcc.ContentCapability;
+import com.marklogic.xcc.ContentPermission;
+
+public class CommaDelimitedPermissionsParser implements PermissionsParser {
+
+    @Override
+    public ContentPermission[] parsePermissions(String text) {
+        List<ContentPermission> list = new ArrayList<ContentPermission>();
+        if (text != null && text.trim().length() > 0) {
+            String[] tokens = text.split(",");
+            for (int i = 0; i < tokens.length; i += 2) {
+                String role = tokens[i];
+                String capability = tokens[i + 1];
+
+                ContentCapability cc = ContentCapability.READ;
+                if (capability.equals("execute")) {
+                    cc = ContentCapability.EXECUTE;
+                } else if (capability.equals("insert")) {
+                    cc = ContentCapability.INSERT;
+                } else if (capability.equals("update")) {
+                    cc = ContentCapability.UPDATE;
+                }
+
+                list.add(new ContentPermission(cc, role));
+            }
+        }
+        return list.toArray(new ContentPermission[] {});
+    }
+
+}

--- a/src/main/java/com/marklogic/appdeployer/command/modules/CommaDelimitedPermissionsParser.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/CommaDelimitedPermissionsParser.java
@@ -6,6 +6,11 @@ import java.util.List;
 import com.marklogic.xcc.ContentCapability;
 import com.marklogic.xcc.ContentPermission;
 
+/**
+ * Simple implementation that expects permissions to be comma-delimited in the format
+ * role1,capability1,role2,capability2,etc - just like when using mlcp.
+ *
+ */
 public class CommaDelimitedPermissionsParser implements PermissionsParser {
 
     @Override
@@ -15,21 +20,22 @@ public class CommaDelimitedPermissionsParser implements PermissionsParser {
             String[] tokens = text.split(",");
             for (int i = 0; i < tokens.length; i += 2) {
                 String role = tokens[i];
-                String capability = tokens[i + 1];
-
-                ContentCapability cc = ContentCapability.READ;
-                if (capability.equals("execute")) {
-                    cc = ContentCapability.EXECUTE;
-                } else if (capability.equals("insert")) {
-                    cc = ContentCapability.INSERT;
-                } else if (capability.equals("update")) {
-                    cc = ContentCapability.UPDATE;
-                }
-
-                list.add(new ContentPermission(cc, role));
+                list.add(new ContentPermission(parseCapability(tokens[i + 1]), role));
             }
         }
         return list.toArray(new ContentPermission[] {});
     }
 
+    protected ContentCapability parseCapability(String capability) {
+        if (capability.equals("execute")) {
+            return ContentCapability.EXECUTE;
+        } else if (capability.equals("insert")) {
+            return ContentCapability.INSERT;
+        } else if (capability.equals("update")) {
+            return ContentCapability.UPDATE;
+        } else if (capability.equals("read")) {
+            return ContentCapability.READ;
+        }
+        throw new IllegalArgumentException("Unrecognized content capability: " + capability);
+    }
 }

--- a/src/main/java/com/marklogic/appdeployer/command/modules/DefaultDocumentFormatGetter.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/DefaultDocumentFormatGetter.java
@@ -4,6 +4,10 @@ import java.io.File;
 
 import com.marklogic.xcc.DocumentFormat;
 
+/**
+ * Default impl that currently doesn't provide any support for binary. Feel free to enhance this, subclass it, or roll
+ * your own.
+ */
 public class DefaultDocumentFormatGetter implements DocumentFormatGetter {
 
     @Override

--- a/src/main/java/com/marklogic/appdeployer/command/modules/DefaultDocumentFormatGetter.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/DefaultDocumentFormatGetter.java
@@ -1,0 +1,18 @@
+package com.marklogic.appdeployer.command.modules;
+
+import java.io.File;
+
+import com.marklogic.xcc.DocumentFormat;
+
+public class DefaultDocumentFormatGetter implements DocumentFormatGetter {
+
+    @Override
+    public DocumentFormat getDocumentFormat(File file) {
+        String name = file.getName();
+        if (name.endsWith(".xml") || name.endsWith(".xsl")) {
+            return DocumentFormat.XML;
+        }
+        return DocumentFormat.TEXT;
+    }
+
+}

--- a/src/main/java/com/marklogic/appdeployer/command/modules/DocumentFormatGetter.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/DocumentFormatGetter.java
@@ -4,6 +4,9 @@ import java.io.File;
 
 import com.marklogic.xcc.DocumentFormat;
 
+/**
+ * Encapsulates the logic for determining the document format of a given file.
+ */
 public interface DocumentFormatGetter {
 
     public DocumentFormat getDocumentFormat(File file);

--- a/src/main/java/com/marklogic/appdeployer/command/modules/DocumentFormatGetter.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/DocumentFormatGetter.java
@@ -1,0 +1,10 @@
+package com.marklogic.appdeployer.command.modules;
+
+import java.io.File;
+
+import com.marklogic.xcc.DocumentFormat;
+
+public interface DocumentFormatGetter {
+
+    public DocumentFormat getDocumentFormat(File file);
+}

--- a/src/main/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccCommand.java
@@ -114,8 +114,8 @@ public class LoadAssetsViaXccCommand extends AbstractCommand implements FileVisi
         if (permissions != null && permissions.trim().length() > 0) {
             String[] tokens = permissions.split(",");
             for (int i = 0; i < tokens.length; i += 2) {
-                String role = tokens[0];
-                String capability = tokens[1];
+                String role = tokens[i];
+                String capability = tokens[i + 1];
 
                 ContentCapability cc = ContentCapability.READ;
                 if (capability.equals("execute")) {

--- a/src/main/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccCommand.java
@@ -71,16 +71,18 @@ public class LoadAssetsViaXccCommand extends AbstractCommand implements FileVisi
                 databaseName != null ? databaseName : config.getModulesDatabaseName());
         activeSession = cs.newSession();
 
-        for (Path path : assetPaths) {
-            this.currentAssetPath = path;
-            try {
-                Files.walkFileTree(path, this);
-            } catch (IOException ie) {
-                throw new RuntimeException("Error while walking assets file tree: " + ie.getMessage(), ie);
-            } finally {
-                activeSession.close();
-                activeSession = null;
+        try {
+            for (Path path : assetPaths) {
+                this.currentAssetPath = path;
+                try {
+                    Files.walkFileTree(path, this);
+                } catch (IOException ie) {
+                    throw new RuntimeException("Error while walking assets file tree: " + ie.getMessage(), ie);
+                }
             }
+        } finally {
+            activeSession.close();
+            activeSession = null;
         }
     }
 

--- a/src/main/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccCommand.java
@@ -1,0 +1,178 @@
+package com.marklogic.appdeployer.command.modules;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.marklogic.appdeployer.AppConfig;
+import com.marklogic.appdeployer.CommandContext;
+import com.marklogic.appdeployer.command.AbstractCommand;
+import com.marklogic.appdeployer.command.SortOrderConstants;
+import com.marklogic.xcc.Content;
+import com.marklogic.xcc.ContentCapability;
+import com.marklogic.xcc.ContentCreateOptions;
+import com.marklogic.xcc.ContentFactory;
+import com.marklogic.xcc.ContentPermission;
+import com.marklogic.xcc.ContentSource;
+import com.marklogic.xcc.ContentSourceFactory;
+import com.marklogic.xcc.DocumentFormat;
+import com.marklogic.xcc.Session;
+import com.marklogic.xcc.exceptions.RequestException;
+
+public class LoadAssetsViaXccCommand extends AbstractCommand implements FileVisitor<Path> {
+
+    private String username;
+    private String password;
+    private String host;
+    private Integer port = 8000;
+    private String databaseName;
+
+    private Path assetsPath;
+    private String permissions = "rest-admin,read,rest-admin,update,rest-extension-user,execute";
+    private String[] collections;
+
+    private Session activeSession;
+
+    public LoadAssetsViaXccCommand(String assetsPath) {
+        this.assetsPath = Paths.get(assetsPath);
+    }
+
+    @Override
+    public Integer getExecuteSortOrder() {
+        return SortOrderConstants.LOAD_MODULES_ORDER - 10;
+    }
+
+    @Override
+    public void execute(CommandContext context) {
+        AppConfig config = context.getAppConfig();
+
+        ContentSource cs = ContentSourceFactory.newContentSource(host != null ? host : config.getHost(), this.port,
+                username != null ? username : config.getUsername(), password != null ? password : config.getPassword(),
+                databaseName != null ? databaseName : config.getModulesDatabaseName());
+        activeSession = cs.newSession();
+
+        try {
+            Files.walkFileTree(assetsPath, this);
+        } catch (IOException ie) {
+            throw new RuntimeException("Error while walking assets file tree: " + ie.getMessage(), ie);
+        } finally {
+            activeSession.close();
+            activeSession = null;
+        }
+    }
+
+    @Override
+    public void undo(CommandContext context) {
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path path, BasicFileAttributes attributes) throws IOException {
+        if (attributes.isRegularFile()) {
+            Path relPath = assetsPath.relativize(path);
+            String uri = "/" + relPath.toString().replace("\\", "/");
+
+            ContentCreateOptions options = new ContentCreateOptions();
+            options.setFormat(determineDocumentFormat(relPath));
+            options.setPermissions(parsePermissions(this.permissions));
+            if (this.collections != null) {
+                options.setCollections(collections);
+            }
+
+            logger.info("Inserting module into URI: " + uri);
+            Content content = ContentFactory.newContent(uri, path.toFile(), options);
+            try {
+                activeSession.insertContent(content);
+            } catch (RequestException re) {
+                throw new RuntimeException("Unable to insert content at URI: " + uri + "; cause: " + re.getMessage(),
+                        re);
+            }
+        }
+        return FileVisitResult.CONTINUE;
+    }
+
+    /**
+     * TODO Toss this into a separate class for reusability/modification.
+     */
+    protected DocumentFormat determineDocumentFormat(Path path) {
+        if (path.endsWith(".xml") || path.endsWith(".xsl")) {
+            return DocumentFormat.XML;
+        }
+        return DocumentFormat.TEXT;
+    }
+
+    /**
+     * TODO Would also be nice to move this to a separate class.
+     */
+    protected ContentPermission[] parsePermissions(String permissions) {
+        List<ContentPermission> list = new ArrayList<ContentPermission>();
+        if (permissions != null && permissions.trim().length() > 0) {
+            String[] tokens = permissions.split(",");
+            for (int i = 0; i < tokens.length; i += 2) {
+                String role = tokens[0];
+                String capability = tokens[1];
+
+                ContentCapability cc = ContentCapability.READ;
+                if (capability.equals("execute")) {
+                    cc = ContentCapability.EXECUTE;
+                } else if (capability.equals("insert")) {
+                    cc = ContentCapability.INSERT;
+                } else if (capability.equals("update")) {
+                    cc = ContentCapability.UPDATE;
+                }
+
+                list.add(new ContentPermission(cc, role));
+            }
+        }
+        return list.toArray(new ContentPermission[] {});
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path arg0, IOException arg1) throws IOException {
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult preVisitDirectory(Path arg0, BasicFileAttributes arg1) throws IOException {
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(Path arg0, IOException arg1) throws IOException {
+        return FileVisitResult.CONTINUE;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public void setPermissions(String permissions) {
+        this.permissions = permissions;
+    }
+
+    public void setCollections(String[] collections) {
+        this.collections = collections;
+    }
+
+    public void setDatabaseName(String databaseName) {
+        this.databaseName = databaseName;
+    }
+
+}

--- a/src/main/java/com/marklogic/appdeployer/command/modules/PermissionsParser.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/PermissionsParser.java
@@ -1,0 +1,8 @@
+package com.marklogic.appdeployer.command.modules;
+
+import com.marklogic.xcc.ContentPermission;
+
+public interface PermissionsParser {
+
+    public ContentPermission[] parsePermissions(String text);
+}

--- a/src/main/java/com/marklogic/appdeployer/command/modules/PermissionsParser.java
+++ b/src/main/java/com/marklogic/appdeployer/command/modules/PermissionsParser.java
@@ -2,6 +2,9 @@ package com.marklogic.appdeployer.command.modules;
 
 import com.marklogic.xcc.ContentPermission;
 
+/**
+ * Strategy interface for how XCC permissions are parsed from text.
+ */
 public interface PermissionsParser {
 
     public ContentPermission[] parsePermissions(String text);

--- a/src/main/java/com/marklogic/rest/util/Fragment.java
+++ b/src/main/java/com/marklogic/rest/util/Fragment.java
@@ -29,6 +29,7 @@ public class Fragment {
             list.add(Namespace.getNamespace("h", "http://marklogic.com/manage/hosts"));
             list.add(Namespace.getNamespace("m", "http://marklogic.com/manage"));
             list.add(Namespace.getNamespace("s", "http://marklogic.com/manage/servers"));
+            list.add(Namespace.getNamespace("sec", "http://marklogic.com/xdmp/security"));
             for (Namespace n : namespaces) {
                 list.add(n);
             }
@@ -56,6 +57,10 @@ public class Fragment {
             values.add(el.getText());
         }
         return values;
+    }
+
+    public List<Element> getElements(String xpath) {
+        return evaluateForElements(xpath);
     }
 
     protected List<Element> evaluateForElements(String xpath) {

--- a/src/test/java/com/marklogic/appdeployer/AbstractAppDeployerTest.java
+++ b/src/test/java/com/marklogic/appdeployer/AbstractAppDeployerTest.java
@@ -16,6 +16,7 @@ import com.marklogic.appdeployer.spring.SpringAppDeployer;
 import com.marklogic.rest.mgmt.AbstractMgmtTest;
 import com.marklogic.rest.mgmt.admin.AdminConfig;
 import com.marklogic.rest.mgmt.admin.AdminManager;
+import com.marklogic.xccutil.template.XccTemplate;
 
 /**
  * Base class for tests that depend on an AppDeployer instance.
@@ -98,5 +99,15 @@ public abstract class AbstractAppDeployerTest extends AbstractMgmtTest {
         } catch (Exception e) {
             logger.warn("Error while waiting for MarkLogic to restart: " + e.getMessage());
         }
+    }
+
+    /**
+     * Assumes that the ManageConfig info can be used to talk XCC to the modules database.
+     * 
+     * @return
+     */
+    protected XccTemplate newModulesXccTemplate() {
+        return new XccTemplate(format("xcc://%s:%s@%s:8000/%s", manageConfig.getUsername(), manageConfig.getPassword(),
+                manageConfig.getHost(), appConfig.getModulesDatabaseName()));
     }
 }

--- a/src/test/java/com/marklogic/appdeployer/AbstractAppDeployerTest.java
+++ b/src/test/java/com/marklogic/appdeployer/AbstractAppDeployerTest.java
@@ -102,12 +102,12 @@ public abstract class AbstractAppDeployerTest extends AbstractMgmtTest {
     }
 
     /**
-     * Assumes that the ManageConfig info can be used to talk XCC to the modules database.
+     * Assumes that the AppConfig user can be used to talk XCC to the modules database.
      * 
      * @return
      */
     protected XccTemplate newModulesXccTemplate() {
-        return new XccTemplate(format("xcc://%s:%s@%s:8000/%s", manageConfig.getUsername(), manageConfig.getPassword(),
-                manageConfig.getHost(), appConfig.getModulesDatabaseName()));
+        return new XccTemplate(format("xcc://%s:%s@%s:8000/%s", appConfig.getUsername(), appConfig.getPassword(),
+                appConfig.getHost(), appConfig.getModulesDatabaseName()));
     }
 }

--- a/src/test/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccTest.java
@@ -1,0 +1,23 @@
+package com.marklogic.appdeployer.command.modules;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.marklogic.appdeployer.AbstractAppDeployerTest;
+import com.marklogic.appdeployer.command.restapis.CreateRestApiServersCommand;
+
+public class LoadAssetsViaXccTest extends AbstractAppDeployerTest {
+
+    @Test
+    public void loadModules() {
+        initializeAppDeployer(new CreateRestApiServersCommand(), new LoadAssetsViaXccCommand(
+                "src/test/resources/sample-app/more-modules"));
+
+        appDeployer.deploy(appConfig);
+    }
+
+    @After
+    public void tearDown() {
+        // undeploySampleApp();
+    }
+}

--- a/src/test/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccTest.java
@@ -5,15 +5,47 @@ import org.junit.Test;
 
 import com.marklogic.appdeployer.AbstractAppDeployerTest;
 import com.marklogic.appdeployer.command.restapis.CreateRestApiServersCommand;
+import com.marklogic.rest.util.Fragment;
+import com.marklogic.xccutil.template.XccTemplate;
 
 public class LoadAssetsViaXccTest extends AbstractAppDeployerTest {
 
+    private XccTemplate xccTemplate;
+
     @Test
-    public void loadModules() {
-        initializeAppDeployer(new CreateRestApiServersCommand(), new LoadAssetsViaXccCommand(
-                "src/test/resources/sample-app/more-modules"));
+    public void defaultPermissionsAndCustomCollections() {
+        LoadAssetsViaXccCommand command = new LoadAssetsViaXccCommand("src/test/resources/sample-app/more-modules");
+        command.setCollections(new String[] { "blue", "red" });
+
+        initializeAppDeployer(new CreateRestApiServersCommand(), command);
 
         appDeployer.deploy(appConfig);
+
+        xccTemplate = newModulesXccTemplate();
+
+        assertModulesWereLoaded("/app/hello-lib.xqy", "/app/models/world-lib.xqy");
+    }
+
+    private void assertModulesWereLoaded(String... uris) {
+        for (String uri : uris) {
+            assertModuleHasTheDefaultPermissions(uri);
+            assertModuleIsInTheCustomCollections(uri);
+        }
+    }
+
+    private void assertModuleHasTheDefaultPermissions(String uri) {
+        String response = xccTemplate.executeAdhocQuery(format("xdmp:document-get-permissions('%s')", uri));
+        Fragment perms = new Fragment("<xml>" + response + "</xml>");
+        assertEquals(format("By default, the module %s should have 3 permissions", uri), 3,
+                perms.getElements("/xml/sec:permission").size());
+    }
+
+    private void assertModuleIsInTheCustomCollections(String uri) {
+        String response = xccTemplate.executeAdhocQuery(format("xdmp:document-get-collections('%s')", uri));
+        String[] collections = response.split("\\n");
+        assertEquals(2, collections.length);
+        assertEquals("blue", collections[0]);
+        assertEquals("red", collections[1]);
     }
 
     @After

--- a/src/test/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/modules/LoadAssetsViaXccTest.java
@@ -12,12 +12,11 @@ import com.marklogic.xccutil.template.XccTemplate;
 public class LoadAssetsViaXccTest extends AbstractAppDeployerTest {
 
     private XccTemplate xccTemplate;
-    private LoadAssetsViaXccCommand command;
 
     @Before
     public void setup() {
         xccTemplate = newModulesXccTemplate();
-        command = new LoadAssetsViaXccCommand("src/test/resources/sample-app/more-modules");
+
     }
 
     @After
@@ -27,6 +26,7 @@ public class LoadAssetsViaXccTest extends AbstractAppDeployerTest {
 
     @Test
     public void defaultPermissionsAndCustomCollections() {
+        LoadAssetsViaXccCommand command = new LoadAssetsViaXccCommand("src/test/resources/sample-app/more-modules");
         command.setCollections(new String[] { "blue", "red" });
 
         initializeAppDeployer(new CreateRestApiServersCommand(), command);
@@ -36,7 +36,9 @@ public class LoadAssetsViaXccTest extends AbstractAppDeployerTest {
     }
 
     @Test
-    public void customPermissions() {
+    public void customPermissionsAndMultipleAssetPaths() {
+        LoadAssetsViaXccCommand command = new LoadAssetsViaXccCommand("src/test/resources/sample-app/more-modules",
+                "src/test/resources/sample-app/other-modules");
         command.setPermissions("rest-admin,read,rest-admin,update,rest-extension-user,execute,rest-extension-user,update");
 
         initializeAppDeployer(new CreateRestApiServersCommand(), command);
@@ -44,6 +46,7 @@ public class LoadAssetsViaXccTest extends AbstractAppDeployerTest {
 
         assertModuleHasPermissionCount("/app/hello-lib.xqy", 4);
         assertModuleHasPermissionCount("/app/models/world-lib.xqy", 4);
+        assertModuleHasPermissionCount("/other-lib.xqy", 4);
     }
 
     private void assertModulesWereLoaded(String... uris) {

--- a/src/test/java/com/marklogic/rest/mgmt/AbstractMgmtTest.java
+++ b/src/test/java/com/marklogic/rest/mgmt/AbstractMgmtTest.java
@@ -20,7 +20,7 @@ import com.marklogic.junit.spring.LoggingTestExecutionListener;
 public abstract class AbstractMgmtTest extends Assert {
 
     @Autowired
-    private ManageConfig manageConfig;
+    protected ManageConfig manageConfig;
 
     // Intended to be used by subclasses
     protected ManageClient manageClient;
@@ -29,4 +29,9 @@ public abstract class AbstractMgmtTest extends Assert {
     public void initializeManageClient() {
         manageClient = new ManageClient(manageConfig);
     }
+
+    protected String format(String s, Object... args) {
+        return String.format(s, args);
+    }
+
 }

--- a/src/test/java/com/marklogic/rest/mgmt/AbstractMgmtTest.java
+++ b/src/test/java/com/marklogic/rest/mgmt/AbstractMgmtTest.java
@@ -20,7 +20,7 @@ import com.marklogic.junit.spring.LoggingTestExecutionListener;
 public abstract class AbstractMgmtTest extends Assert {
 
     @Autowired
-    protected ManageConfig manageConfig;
+    private ManageConfig manageConfig;
 
     // Intended to be used by subclasses
     protected ManageClient manageClient;

--- a/src/test/resources/sample-app/more-modules/app/hello-lib.xqy
+++ b/src/test/resources/sample-app/more-modules/app/hello-lib.xqy
@@ -1,0 +1,8 @@
+xquery version "1.0-ml";
+
+module namespace hello = "urn:sampleapp:hello";
+
+declare function hello($str as xs:string?) as xs:string
+{
+  "Hello: " || $str
+};

--- a/src/test/resources/sample-app/more-modules/app/models/world-lib.xqy
+++ b/src/test/resources/sample-app/more-modules/app/models/world-lib.xqy
@@ -1,0 +1,8 @@
+xquery version "1.0-ml";
+
+module namespace world = "urn:sampleapp:world";
+
+declare function world($str as xs:string?) as xs:string
+{
+  "World: " || $str
+};

--- a/src/test/resources/sample-app/other-modules/other-lib.xqy
+++ b/src/test/resources/sample-app/other-modules/other-lib.xqy
@@ -1,0 +1,8 @@
+xquery version "1.0-ml";
+
+module namespace other = "urn:sampleapp:other";
+
+declare function hello($str as xs:string?) as xs:string
+{
+  "Hello: " || $str
+};


### PR DESCRIPTION
This doesn't depend on the Mgmt API. It's just a convenience that we've needed at World Bank, and it's also nice for when assets are stored in a folder separate from the other REST API modules, such as in a Roxy project. Loading via XCC is often quicker than mlcp, as mlcp has a bit more overhead with starting up.

This also depends on ML8, as it uses port 8000 for talking XCC. 