### PR TITLE
Get RestApi Configuration test, getting an error

### DIFF
--- a/src/test/java/com/rjrudin/marklogic/mgmt/ManageRestApisTest.java
+++ b/src/test/java/com/rjrudin/marklogic/mgmt/ManageRestApisTest.java
@@ -1,0 +1,15 @@
+package com.rjrudin.marklogic.mgmt;
+
+import org.junit.Test;
+
+import com.rjrudin.marklogic.rest.util.Fragment;
+
+public class ManageRestApisTest extends AbstractMgmtTest {
+	
+	@Test
+	public void getRestApiConfigTest() {
+		 Fragment frag = manageClient.getXml("/v1/rest-apis", "rapi", "http://marklogic.com/rest-api");
+		 assertTrue(frag.elementExists("//rapi:name[text() = 'App-Services']"));
+	}
+
+}


### PR DESCRIPTION
Rob - I was using the ManageClient to get the configuration for the Rest APIs and came across this error.  See the attached unit test.