### PR TITLE
#75 Added support for mimetypes

### DIFF
--- a/CHANGELOG.mdown
+++ b/CHANGELOG.mdown
@@ -3,6 +3,7 @@
 ## 2.0rc3 - TBD
 
 * [#74](https://github.com/rjrudin/ml-app-deployer/issues/74) New command for verifying that MarkLogic version is at least 8
+* [#75](https://github.com/rjrudin/ml-app-deployer/issues/75) Added mimetypes support
 
 ## 2.0rc2 - 2016-01-03
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ if (project.hasProperty("myBintrayUser")) {
       licenses = ['Apache-2.0']
       vcsUrl = 'https://github.com/rjrudin/' + project.name + '.git'
       version {
-        name = "2.0rc2"
+        name = "2.0rc3"
         released = new Date()
       }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=com.marklogic
 publishUrl=file:../gh-pages-marklogic-java/releases
 javadocsDir=../gh-pages-marklogic-java/javadocs
-version=2.0rc2
+version=2.0rc3
 
 
 # Old CHANGELOG

--- a/src/main/java/com/marklogic/appdeployer/command/SortOrderConstants.java
+++ b/src/main/java/com/marklogic/appdeployer/command/SortOrderConstants.java
@@ -12,7 +12,8 @@ public abstract class SortOrderConstants {
     public static Integer DEPLOY_CERTIFICATE_AUTHORITIES = 60;
     public static Integer DEPLOY_EXTERNAL_SECURITY = 70;
     public static Integer DEPLOY_PROTECTED_COLLECTIONS = 80;
-
+    public static Integer DEPLOY_MIMETYPES = 90;
+    
     public static Integer DEPLOY_TRIGGERS_DATABASE = 100;
     public static Integer DEPLOY_SCHEMAS_DATABASE = 100;
     public static Integer DEPLOY_CONTENT_DATABASES = 120;
@@ -53,6 +54,8 @@ public abstract class SortOrderConstants {
     // Undo constants
     public static Integer DELETE_GROUPS = 10000;
 
+    public static Integer DELETE_MIMETYPES = 9500;
+    
     public static Integer DELETE_USERS = 9000;
     public static Integer DELETE_CERTIFICATE_TEMPLATES = 9010;
     public static Integer DELETE_CERTIFICATE_AUTHORITIES = 9020;

--- a/src/main/java/com/marklogic/appdeployer/command/mimetypes/DeployMimetypesCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/mimetypes/DeployMimetypesCommand.java
@@ -1,0 +1,37 @@
+package com.marklogic.appdeployer.command.mimetypes;
+
+import java.io.File;
+
+import com.marklogic.appdeployer.command.AbstractResourceCommand;
+import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.mgmt.ResourceManager;
+import com.marklogic.mgmt.SaveReceipt;
+import com.marklogic.mgmt.mimetypes.MimetypeManager;
+
+public class DeployMimetypesCommand extends AbstractResourceCommand {
+
+    public DeployMimetypesCommand() {
+        setRestartAfterDelete(true);
+    }
+
+    @Override
+    protected File[] getResourceDirs(CommandContext context) {
+        return new File[] { new File(context.getAppConfig().getConfigDir().getBaseDir(), "mimetypes") };
+    }
+
+    @Override
+    protected ResourceManager getResourceManager(CommandContext context) {
+        return new MimetypeManager(context.getManageClient());
+    }
+
+    /**
+     * As of ML 8.0-4, any time a mimetype is created or updated, ML must be restarted.
+     */
+    @Override
+    protected void afterResourceSaved(ResourceManager mgr, CommandContext context, File resourceFile,
+            SaveReceipt receipt) {
+        logger.info("Waiting for restart after saving mimetype");
+        context.getAdminManager().waitForRestart();
+    }
+
+}

--- a/src/main/java/com/marklogic/appdeployer/command/mimetypes/DeployMimetypesCommand.java
+++ b/src/main/java/com/marklogic/appdeployer/command/mimetypes/DeployMimetypesCommand.java
@@ -4,6 +4,7 @@ import java.io.File;
 
 import com.marklogic.appdeployer.command.AbstractResourceCommand;
 import com.marklogic.appdeployer.command.CommandContext;
+import com.marklogic.appdeployer.command.SortOrderConstants;
 import com.marklogic.mgmt.ResourceManager;
 import com.marklogic.mgmt.SaveReceipt;
 import com.marklogic.mgmt.mimetypes.MimetypeManager;
@@ -11,6 +12,8 @@ import com.marklogic.mgmt.mimetypes.MimetypeManager;
 public class DeployMimetypesCommand extends AbstractResourceCommand {
 
     public DeployMimetypesCommand() {
+        setExecuteSortOrder(SortOrderConstants.DEPLOY_MIMETYPES);
+        setUndoSortOrder(SortOrderConstants.DELETE_MIMETYPES);
         setRestartAfterDelete(true);
     }
 

--- a/src/main/java/com/marklogic/mgmt/mimetypes/MimetypeManager.java
+++ b/src/main/java/com/marklogic/mgmt/mimetypes/MimetypeManager.java
@@ -1,0 +1,17 @@
+package com.marklogic.mgmt.mimetypes;
+
+import com.marklogic.mgmt.AbstractResourceManager;
+import com.marklogic.mgmt.ManageClient;
+
+public class MimetypeManager extends AbstractResourceManager {
+
+    public MimetypeManager(ManageClient client) {
+        super(client);
+    }
+
+    @Override
+    protected String getIdFieldName() {
+        return "name";
+    }
+
+}

--- a/src/test/java/com/marklogic/appdeployer/command/mimetypes/ManageMimetypesTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/mimetypes/ManageMimetypesTest.java
@@ -1,0 +1,25 @@
+package com.marklogic.appdeployer.command.mimetypes;
+
+import com.marklogic.appdeployer.command.AbstractManageResourceTest;
+import com.marklogic.appdeployer.command.Command;
+import com.marklogic.mgmt.ResourceManager;
+import com.marklogic.mgmt.mimetypes.MimetypeManager;
+
+public class ManageMimetypesTest extends AbstractManageResourceTest {
+
+    @Override
+    protected ResourceManager newResourceManager() {
+        return new MimetypeManager(manageClient);
+    }
+
+    @Override
+    protected Command newCommand() {
+        return new DeployMimetypesCommand();
+    }
+
+    @Override
+    protected String[] getResourceNames() {
+        return new String[] { "text/gradle" };
+    }
+
+}

--- a/src/test/resources/sample-app/src/main/ml-config/mimetypes/gradle.json
+++ b/src/test/resources/sample-app/src/main/ml-config/mimetypes/gradle.json
@@ -1,0 +1,8 @@
+{
+  "name": "text/gradle",
+  "extension": [
+    "gradle",
+    "grdle"
+  ],
+  "format": "text"
+}


### PR DESCRIPTION
This is a common way of adding support for a new Management resource (in this case, mimetypes). The Management API has a lot of patterns in how endpoints work, and in this case, I was able to extend base classes for a manager and for a command, and that was it. Only tricky part was that ML has to restart any time mimetypes are modified. 